### PR TITLE
Fix SceneKit objects lagging behind

### DIFF
--- a/VuforiaSampleSwift/VuforiaManager/VuforiaEAGLView.mm
+++ b/VuforiaSampleSwift/VuforiaManager/VuforiaEAGLView.mm
@@ -417,6 +417,9 @@ namespace VuforiaEAGLViewUtils
         VuforiaEAGLViewUtils::scalePoseMatrix(_objectScale,  _objectScale,  _objectScale, &modelViewMatrix.data[0]);
         
         [self setCameraMatrix:modelViewMatrix]; // SCNCameraにセット
+		
+        [SCNTransaction flush];
+		
         CFAbsoluteTime currentTime = CFAbsoluteTimeGetCurrent() - _startTime;
         [_renderer renderAtTime: currentTime]; // render using SCNRenderer
         


### PR DESCRIPTION
Fixed issue mentioned here:
https://github.com/yshrkt/VuforiaSampleSwift/issues/8

Solution from here:
https://stackoverflow.com/questions/44836314/why-is-scnrenderer-so-out-of-sync-laggy-when-drawing-into-an-opengl-context